### PR TITLE
Patch AnchorLink to pass href to Chakra Link component

### DIFF
--- a/src/components/common/AnchorLink.tsx
+++ b/src/components/common/AnchorLink.tsx
@@ -18,7 +18,7 @@ export function AnchorLink({
   ...props
 }: TAnchorLinkProps): React.ReactElement {
   return (
-    <NextLink href={href}>
+    <NextLink href={href} passHref>
       <Link variant={variant} isExternal={isExternal} {...props}>
         {children}
       </Link>


### PR DESCRIPTION
## Description
As shown in the docs [here](https://chakra-ui.com/docs/components/navigation/link#usage-with-nextjs), this passes the href to the Chakra Link

## Changes
- AnchorLink.tsx line 21
